### PR TITLE
Add release-aligned AODS usage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ npx aods scaffold authoring-touch ./aods/authoring.json --match package.json --l
 npx aods scaffold authoring-pair ./aods/authoring.json --pair-id pair-delivery-log --agent-primary delivery-gates --human-primary DELIVERY-LOG.md
 ```
 
+### Optional: install the release-aligned Copilot skill
+
+If you want another agent to work inside an AODS repo without loading the whole standard first, copy `skills/aods-use/` from the same release tag into that agent's skills directory.
+
+This skill is intentionally thin. It helps an agent:
+
+- detect whether the repo is source-first or compiled-corpus-first
+- choose the minimal correct AODS command path
+- respect `agent-primary` authority instead of treating human-oriented docs as a second source of truth
+
 ### Clone the repository directly
 
 Use this mode if you want the full standard repo, benchmark lab, and examples locally:
@@ -362,6 +372,7 @@ This project is released under the **MIT License**. See [`LICENSE`](./LICENSE).
 AODS now uses two version tracks:
 
 - **Release version:** Git tags and package releases such as `v0.3.0`
+- **Release-aligned skill version:** packaged skills under `skills/` stay aligned to the same release tag
 - **Schema compatibility:** surface-local markers such as `aods_v` and `authoring_v`
 
 Schema markers remain important for compatibility and migration, but they are no longer the public product label in README surfaces. Public-facing docs should refer to the release version, not legacy schema-generation branding.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,6 +73,16 @@ npx aods scaffold authoring-touch ./aods/authoring.json --match package.json --l
 npx aods scaffold authoring-pair ./aods/authoring.json --pair-id pair-delivery-log --agent-primary delivery-gates --human-primary DELIVERY-LOG.md
 ```
 
+### 可选：安装与发布版本对齐的 Copilot skill
+
+如果你希望别的 agent 在 AODS 仓库里工作时，不用先加载整套规范再开始，可以把同一 release tag 下的 `skills/aods-use/` 复制到对应 agent 的 skills 目录。
+
+这个 skill 故意保持很薄，只负责帮助 agent：
+
+- 判断当前仓库是 source-first 还是 compiled-corpus-first
+- 选择最小且正确的 AODS 命令路径
+- 明确 `agent-primary` 才是 authority，不把面向人阅读的文档当成第二套真相源
+
 ### 直接克隆仓库
 
 如果你要本地拿到完整标准仓、benchmark 实验室和 examples，用这种方式：
@@ -362,6 +372,7 @@ node ./bin/aods.mjs scaffold authoring-pair ./examples/compiled-pilot-source/aut
 AODS 现在区分两条版本线：
 
 - **Release version：** Git tag / package release，例如 `v0.3.0`
+- **与发布版对齐的 skill 版本：** `skills/` 下的技能与同一个 release tag 对齐
 - **Schema compatibility：** 各 surface 内部使用的兼容性标记，例如 `aods_v` 和 `authoring_v`
 
 这些 schema 标记依然用于兼容和升级，但不再作为 README 里的对外产品标签。对外文档默认应该使用 release version，而不是遗留的 schema-generation branding。

--- a/benchmarks/aods-eval-lab/test/skill-package.test.mjs
+++ b/benchmarks/aods-eval-lab/test/skill-package.test.mjs
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { REPO_ROOT } from "../src/helpers.mjs";
+
+test("aods-use skill stays release-aligned and keeps a narrow trigger contract", () => {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"));
+  const skillMeta = JSON.parse(
+    fs.readFileSync(path.join(REPO_ROOT, "skills", "aods-use", "skill.json"), "utf8")
+  );
+  const skillText = fs.readFileSync(path.join(REPO_ROOT, "skills", "aods-use", "SKILL.md"), "utf8");
+
+  assert.equal(skillMeta.name, "aods-use");
+  assert.equal(skillMeta.skill_version, packageJson.version);
+  assert.equal(skillMeta.aligned_release, `v${packageJson.version}`);
+  assert.deepEqual(skillMeta.compatibility, {
+    aods_v: 3,
+    authoring_v: 1
+  });
+  assert.equal(skillMeta.entrypoint, "SKILL.md");
+
+  assert.match(skillText, /Use when working in an AODS-enabled repo/);
+  assert.match(skillText, /Detect source-first vs compiled-corpus-first/);
+  assert.match(skillText, /Expected trigger:/);
+  assert.match(skillText, /Expected first action:/);
+  assert.match(skillText, /Negative trigger:/);
+  assert.match(skillText, /Observed result after edit:/);
+
+  assert.ok(skillMeta.positive_triggers.some((item) => item.includes("surface_pairs")));
+  assert.ok(skillMeta.negative_triggers.some((item) => item.includes("generic README")));
+});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lib/",
     "schema/",
     "spec/",
+    "skills/",
     "examples/compiled-pilot-source/",
     "manifest.json",
     "README.md",

--- a/skills/aods-use/SKILL.md
+++ b/skills/aods-use/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: aods-use
+description: Use when working in an AODS-enabled repo or with AODS files and commands such as authoring.json, manifest.json, surface_pairs, boot.by_touch, or aods compile/validate/route.
+---
+
+# AODS Use
+
+Use this skill as an operations adapter, not as a second copy of the AODS spec.
+
+## Version alignment
+
+- Release version: `v0.3.0`
+- Package version: `0.3.0`
+- Compatibility markers: `aods_v=3`, `authoring_v=1`
+- Source of truth: installed AODS CLI plus repo `schema/`, `spec/`, and manifest surfaces
+
+## Use when
+
+- working inside an AODS-enabled repository
+- editing `authoring.json`, `manifest.json`, `modules/*.json`, or `indexes/runtime.json`
+- changing `surface_pairs`, `shared_invariants`, or `boot.by_touch`
+- deciding whether to use `aods compile`, `aods validate`, `aods route`, or authoring scaffold helpers
+
+## Do not use when
+
+- editing generic Markdown outside AODS context
+- editing generic JSON that is not part of an AODS corpus
+- doing broad docs work where AODS structure is irrelevant
+
+## First action
+
+1. Detect repository shape:
+   - source-first if `authoring.json` exists
+   - compiled-corpus-first if `manifest.json` exists without `authoring.json`
+2. Identify the task lane: authoring, sync, routing, or validation.
+3. Choose the minimal correct AODS path before editing:
+   - authoring structure: `aods scaffold authoring-module`, `aods scaffold authoring-touch`, `aods scaffold authoring-pair`
+   - source-first changes that must regenerate output: `aods compile ...`
+   - structural or paired-surface edits: `aods validate ... --strict`
+   - minimal context loading or routing checks: `aods route ...`
+4. Treat `agent-primary` as authority. Human-oriented docs do not replace agent-primary semantic authority.
+
+## Trigger contract
+
+Expected trigger: `Update surface_pairs in authoring.json and make sure shared_invariants still pass.`
+
+Expected first action: `Detect source-first vs compiled-corpus-first, then choose the minimal AODS command path before editing.`
+
+Negative trigger: `Fix wording in a generic README that does not use AODS.`
+
+Observed result after edit: `Repo tests verify release alignment and the trigger contract for this skill package.`

--- a/skills/aods-use/skill.json
+++ b/skills/aods-use/skill.json
@@ -1,0 +1,28 @@
+{
+  "name": "aods-use",
+  "skill_version": "0.3.0",
+  "aligned_release": "v0.3.0",
+  "entrypoint": "SKILL.md",
+  "compatibility": {
+    "aods_v": 3,
+    "authoring_v": 1
+  },
+  "source_of_truth": [
+    "package.json",
+    "bin/aods.mjs",
+    "schema/",
+    "spec/"
+  ],
+  "expected_first_action": "Detect source-first vs compiled-corpus-first, identify the task lane, then choose the minimal AODS command path before editing.",
+  "positive_triggers": [
+    "Work in an AODS-enabled repository",
+    "Edit authoring.json or manifest.json",
+    "Update surface_pairs, shared_invariants, or boot.by_touch",
+    "Use aods compile, aods validate, aods route, or scaffold helpers"
+  ],
+  "negative_triggers": [
+    "Edit a generic README that does not use AODS",
+    "Edit a generic JSON payload outside an AODS corpus",
+    "Do broad docs work where AODS structure is irrelevant"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a thin `skills/aods-use/` package aligned to the current AODS release
- include sidecar skill metadata for release/version compatibility and trigger-contract documentation
- add regression coverage for skill-package alignment and trigger scope
- document how to install the release-aligned skill from the tagged repo

## Validation
- `npm run validate:all`
- `npm run benchmark:test`

Closes #7