### PR TITLE
Add a stricter one-step compile workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ npx aods validate ./docs/aods --strict --reality
 npx aods validate ./docs/aods --strict --reality --repo-root .
 ```
 
-Use `compile --strict` when the compile command itself should be the acceptance gate. It still writes the target corpus, but exits non-zero and prints the blocking warnings instead of looking green prematurely. Use `--reality` only when your corpus declares `surface-inventory` artifacts and you want AODS to verify declared **current** surfaces. For `content.base: "corpus"`, paths resolve from the corpus root. For `content.base: "repo"`, paths resolve from `--repo-root` when supplied; otherwise they also resolve from the corpus root. `reserved` and `future` entries stay as planned surfaces, so they are recorded without being required to exist yet. Current directories must contain real material, not only placeholder files such as `.gitkeep`.
+Use `compile --strict` when the compile command itself should be the acceptance gate. It compiles into staging, validates there, and only updates the target corpus when the strict gate passes. On strict warning or error failure, the command exits non-zero, prints the blocking issues, and leaves the target untouched. Use `--reality` only when your corpus declares `surface-inventory` artifacts and you want AODS to verify declared **current** surfaces. For `content.base: "corpus"`, paths resolve from the corpus root. For `content.base: "repo"`, paths resolve from `--repo-root` when supplied; otherwise they also resolve from the corpus root. `reserved` and `future` entries stay as planned surfaces, so they are recorded without being required to exist yet. Current directories must contain real material, not only placeholder files such as `.gitkeep`.
 
 ```json
 {"type":"surface-inventory","content":{"base":"repo","entries":[{"surface_id":"web-src","path":"apps/web/src","kind":"directory","state":"current"}]}}
@@ -325,7 +325,7 @@ The compile command emits:
 - declared manual human-oriented files such as `README.md`
 - opt-in deterministic generated human-oriented files such as overview or checklist surfaces
 
-`compile --strict` turns that compile step into a real gate: warnings still write output, but they no longer return success-shaped status.
+`compile --strict` turns that compile step into a real gate: warnings or errors stop promotion to the target corpus instead of replacing a previously accepted output.
 
 When `boot_by_role` is present, compiled companion `roles` are reduced to runtime role profiles: `id` plus optional `capabilities`. `required_modules` is kept only when it differs from the boot binding.
 

--- a/README.md
+++ b/README.md
@@ -65,13 +65,12 @@ npx aods scaffold authoring ./aods --sys my-system --purpose "Agent-first docs f
 4. Compile and validate the AODS docs bundle you will keep in your own repository:
 
 ```bash
-npx aods compile ./aods/authoring.json ./docs/aods --force
-npx aods validate ./docs/aods --strict
+npx aods compile ./aods/authoring.json ./docs/aods --force --strict
 npx aods validate ./docs/aods --strict --reality
 npx aods validate ./docs/aods --strict --reality --repo-root .
 ```
 
-Use `--reality` only when your corpus declares `surface-inventory` artifacts and you want AODS to verify declared **current** surfaces. For `content.base: "corpus"`, paths resolve from the corpus root. For `content.base: "repo"`, paths resolve from `--repo-root` when supplied; otherwise they also resolve from the corpus root. `reserved` and `future` entries stay as planned surfaces, so they are recorded without being required to exist yet. Current directories must contain real material, not only placeholder files such as `.gitkeep`.
+Use `compile --strict` when the compile command itself should be the acceptance gate. It still writes the target corpus, but exits non-zero and prints the blocking warnings instead of looking green prematurely. Use `--reality` only when your corpus declares `surface-inventory` artifacts and you want AODS to verify declared **current** surfaces. For `content.base: "corpus"`, paths resolve from the corpus root. For `content.base: "repo"`, paths resolve from `--repo-root` when supplied; otherwise they also resolve from the corpus root. `reserved` and `future` entries stay as planned surfaces, so they are recorded without being required to exist yet. Current directories must contain real material, not only placeholder files such as `.gitkeep`.
 
 ```json
 {"type":"surface-inventory","content":{"base":"repo","entries":[{"surface_id":"web-src","path":"apps/web/src","kind":"directory","state":"current"}]}}
@@ -294,7 +293,7 @@ Routing precedence:
 ```bash
 node ./bin/aods.mjs scaffold authoring ./tmp/authoring-source --sys sample-system --force
 npm run compile:pilot
-node ./bin/aods.mjs compile ./examples/compiled-pilot-source/authoring.json ./tmp/compiled-pilot --force
+node ./bin/aods.mjs compile ./examples/compiled-pilot-source/authoring.json ./tmp/compiled-pilot --force --strict
 ```
 
 Authoring sources now validate against `schema/authoring.schema.json`, so compiled authoring is a real contract rather than a one-off pilot format. Modules may be section-first, artifact-first, or mixed; compiled AODS only requires at least one `section` or `artifact`.
@@ -325,6 +324,8 @@ The compile command emits:
 - copied AODS schemas
 - declared manual human-oriented files such as `README.md`
 - opt-in deterministic generated human-oriented files such as overview or checklist surfaces
+
+`compile --strict` turns that compile step into a real gate: warnings still write output, but they no longer return success-shaped status.
 
 When `boot_by_role` is present, compiled companion `roles` are reduced to runtime role profiles: `id` plus optional `capabilities`. `required_modules` is kept only when it differs from the boot binding.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,7 +70,7 @@ npx aods validate ./docs/aods --strict --reality
 npx aods validate ./docs/aods --strict --reality --repo-root .
 ```
 
-当你希望 `compile` 自己就是 acceptance gate 时，用 `compile --strict`。它仍然会写出目标 corpus，但如果有 warning，会直接非零退出，并把阻断的 warning 打出来，而不是先表现成一次“看起来成功”的编译。只有在你的 corpus 里声明了 `surface-inventory`，并且你想让 AODS 进一步检查这些标记为 **current** 的 surface 时，才需要加 `--reality`。当 `content.base: "corpus"` 时，路径从 corpus root 解析；当 `content.base: "repo"` 时，路径优先从 `--repo-root` 解析，如果没有传，就回退到 corpus root。`reserved` 和 `future` 只表示预留或未来规划，不要求它们现在就已经落地。对于标记为 current 的目录，AODS 还会检查里面是否有真实内容，而不只是 `.gitkeep` 之类的占位文件。
+当你希望 `compile` 自己就是 acceptance gate 时，用 `compile --strict`。它会先编译到 staging，再在那里做校验；只有 strict gate 通过后，才会真正更新目标 corpus。只要 warning 或 error 让 strict gate 失败，命令就会非零退出，打印阻断原因，并保持目标目录不被这次失败结果覆盖。只有在你的 corpus 里声明了 `surface-inventory`，并且你想让 AODS 进一步检查这些标记为 **current** 的 surface 时，才需要加 `--reality`。当 `content.base: "corpus"` 时，路径从 corpus root 解析；当 `content.base: "repo"` 时，路径优先从 `--repo-root` 解析，如果没有传，就回退到 corpus root。`reserved` 和 `future` 只表示预留或未来规划，不要求它们现在就已经落地。对于标记为 current 的目录，AODS 还会检查里面是否有真实内容，而不只是 `.gitkeep` 之类的占位文件。
 
 ```json
 {"type":"surface-inventory","content":{"base":"repo","entries":[{"surface_id":"web-src","path":"apps/web/src","kind":"directory","state":"current"}]}}
@@ -323,7 +323,7 @@ paired human output 现在有两种建模方式：
 - 声明过的面向人阅读文件，例如 `README.md`
 - 按 pair opt-in 生成的 deterministic human-oriented 文件，例如 overview 或 checklist surface
 
-`compile --strict` 会把这一步真正变成 gate：warning 仍然会写出输出，但不会再返回成功形态的结果。
+`compile --strict` 会把这一步真正变成 gate：warning 或 error 会阻止结果被提升到目标 corpus，而不是替换掉一个之前已经通过的输出。
 
 当 `boot_by_role` 已经存在时，编译产物里的 companion `roles` 会被压缩成 runtime role profile：保留 `id` 和可选的 `capabilities`；只有当 `required_modules` 与 boot binding 不一致时才会额外保留。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,13 +65,12 @@ npx aods scaffold authoring ./aods --sys my-system --purpose "Agent-first docs f
 4. 把它编译并校验成你自己仓库里的 AODS 文档目录：
 
 ```bash
-npx aods compile ./aods/authoring.json ./docs/aods --force
-npx aods validate ./docs/aods --strict
+npx aods compile ./aods/authoring.json ./docs/aods --force --strict
 npx aods validate ./docs/aods --strict --reality
 npx aods validate ./docs/aods --strict --reality --repo-root .
 ```
 
-只有在你的 corpus 里声明了 `surface-inventory`，并且你想让 AODS 进一步检查这些标记为 **current** 的 surface 时，才需要加 `--reality`。当 `content.base: "corpus"` 时，路径从 corpus root 解析；当 `content.base: "repo"` 时，路径优先从 `--repo-root` 解析，如果没有传，就回退到 corpus root。`reserved` 和 `future` 只表示预留或未来规划，不要求它们现在就已经落地。对于标记为 current 的目录，AODS 还会检查里面是否有真实内容，而不只是 `.gitkeep` 之类的占位文件。
+当你希望 `compile` 自己就是 acceptance gate 时，用 `compile --strict`。它仍然会写出目标 corpus，但如果有 warning，会直接非零退出，并把阻断的 warning 打出来，而不是先表现成一次“看起来成功”的编译。只有在你的 corpus 里声明了 `surface-inventory`，并且你想让 AODS 进一步检查这些标记为 **current** 的 surface 时，才需要加 `--reality`。当 `content.base: "corpus"` 时，路径从 corpus root 解析；当 `content.base: "repo"` 时，路径优先从 `--repo-root` 解析，如果没有传，就回退到 corpus root。`reserved` 和 `future` 只表示预留或未来规划，不要求它们现在就已经落地。对于标记为 current 的目录，AODS 还会检查里面是否有真实内容，而不只是 `.gitkeep` 之类的占位文件。
 
 ```json
 {"type":"surface-inventory","content":{"base":"repo","entries":[{"surface_id":"web-src","path":"apps/web/src","kind":"directory","state":"current"}]}}
@@ -292,7 +291,7 @@ Routing precedence：
 ```bash
 node ./bin/aods.mjs scaffold authoring ./tmp/authoring-source --sys sample-system --force
 npm run compile:pilot
-node ./bin/aods.mjs compile ./examples/compiled-pilot-source/authoring.json ./tmp/compiled-pilot --force
+node ./bin/aods.mjs compile ./examples/compiled-pilot-source/authoring.json ./tmp/compiled-pilot --force --strict
 ```
 
 authoring source 现在会按照 `schema/authoring.schema.json` 校验，所以 compiled authoring 已经不再只是一次性的 pilot 格式，而是正式契约。module 现在既可以是 section-first，也可以是 artifact-first，或者两者混合；编译后的 AODS 只要求至少有一个 `section` 或 `artifact`。
@@ -323,6 +322,8 @@ paired human output 现在有两种建模方式：
 - 拷贝后的 AODS schemas
 - 声明过的面向人阅读文件，例如 `README.md`
 - 按 pair opt-in 生成的 deterministic human-oriented 文件，例如 overview 或 checklist surface
+
+`compile --strict` 会把这一步真正变成 gate：warning 仍然会写出输出，但不会再返回成功形态的结果。
 
 当 `boot_by_role` 已经存在时，编译产物里的 companion `roles` 会被压缩成 runtime role profile：保留 `id` 和可选的 `capabilities`；只有当 `required_modules` 与 boot binding 不一致时才会额外保留。
 

--- a/benchmarks/aods-eval-lab/test/scaffold.test.mjs
+++ b/benchmarks/aods-eval-lab/test/scaffold.test.mjs
@@ -135,8 +135,27 @@ test("compile --strict turns warning-only output into a failing gate", () => {
   assert.notEqual(strictCompile.status, 0);
   assert.match(strictCompile.stdout, /FAIL compile corpus/);
   assert.match(strictCompile.stdout, /strict gate blocked by warnings/);
+  assert.match(strictCompile.stdout, /target not updated because strict gate failed/);
   assert.match(strictCompile.stdout, /surface-pair-bidirectional-sync/);
-  assert.ok(fs.existsSync(path.join(tempDir, "compiled-strict", "manifest.json")));
+  assert.equal(fs.existsSync(path.join(tempDir, "compiled-strict", "manifest.json")), false);
+
+  const preservedRoot = path.join(tempDir, "compiled-preserved");
+  fs.mkdirSync(preservedRoot, { recursive: true });
+  fs.writeFileSync(path.join(preservedRoot, "sentinel.txt"), "keep me");
+  const preservedCompile = spawnSync("node", [
+    CLI_PATH,
+    "compile",
+    sourcePath,
+    preservedRoot,
+    "--force",
+    "--strict"
+  ], {
+    cwd: REPO_ROOT,
+    encoding: "utf8"
+  });
+  assert.notEqual(preservedCompile.status, 0);
+  assert.equal(fs.readFileSync(path.join(preservedRoot, "sentinel.txt"), "utf8"), "keep me");
+  assert.equal(fs.existsSync(path.join(preservedRoot, "manifest.json")), false);
 
   const strictJsonCompile = spawnSync("node", [
     CLI_PATH,
@@ -154,6 +173,9 @@ test("compile --strict turns warning-only output into a failing gate", () => {
   const strictJson = JSON.parse(strictJsonCompile.stdout);
   assert.equal(strictJson.strict, true);
   assert.equal(strictJson.status, "fail");
+  assert.equal(strictJson.accepted, false);
+  assert.equal(strictJson.written, false);
+  assert.deepEqual(strictJson.created_files, []);
   assert.equal(strictJson.validation.errors, 0);
   assert.ok(strictJson.validation.warnings > 0);
 });

--- a/benchmarks/aods-eval-lab/test/scaffold.test.mjs
+++ b/benchmarks/aods-eval-lab/test/scaffold.test.mjs
@@ -19,6 +19,7 @@ function runCli(args) {
 test("CLI help and compile errors expose allowed enum values", () => {
   const help = runCli(["--help"]);
   assert.match(help, /authoring-module/);
+  assert.match(help, /aods compile <source-file> <target-dir> \[--json\] \[--strict\] \[--force\]/);
   assert.match(help, /module category: architecture \| protocol \| schema \| workflow \| policy \| config \| reference \| artifact \| capsule/);
   assert.match(help, /module scaffold pattern: implementation-governance/);
 
@@ -56,6 +57,105 @@ test("CLI help and compile errors expose allowed enum values", () => {
   assert.match(result.stderr, /Received: "plan"/);
   assert.match(result.stderr, /Allowed values:/);
   assert.match(result.stderr, /"architecture"/);
+});
+
+test("compile --strict turns warning-only output into a failing gate", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "aods-compile-strict-"));
+  runCli(["scaffold", "authoring", tempDir, "--sys", "demo-system", "--force"]);
+
+  const sourcePath = path.join(tempDir, "authoring.json");
+  runCli([
+    "scaffold",
+    "authoring-module",
+    sourcePath,
+    "delivery-gates",
+    "--category",
+    "policy",
+    "--layer",
+    "detail",
+    "--scope",
+    "Delivery gate authority"
+  ]);
+  runCli([
+    "scaffold",
+    "authoring-pair",
+    sourcePath,
+    "--pair-id",
+    "pair-delivery-log",
+    "--agent-primary",
+    "delivery-gates",
+    "--human-primary",
+    "DELIVERY-LOG.md"
+  ]);
+
+  const cleanCompile = spawnSync("node", [
+    CLI_PATH,
+    "compile",
+    sourcePath,
+    path.join(tempDir, "compiled-clean"),
+    "--force",
+    "--strict"
+  ], {
+    cwd: REPO_ROOT,
+    encoding: "utf8"
+  });
+  assert.equal(cleanCompile.status, 0);
+  assert.match(cleanCompile.stdout, /OK compile corpus/);
+  assert.doesNotMatch(cleanCompile.stdout, /strict gate blocked by warnings/);
+
+  const source = JSON.parse(fs.readFileSync(sourcePath, "utf8"));
+  source.surface_pairs[0].sync_source = "bidirectional";
+  fs.writeFileSync(sourcePath, `${JSON.stringify(source, null, 2)}\n`);
+
+  const warningCompile = spawnSync("node", [
+    CLI_PATH,
+    "compile",
+    sourcePath,
+    path.join(tempDir, "compiled-warning"),
+    "--force"
+  ], {
+    cwd: REPO_ROOT,
+    encoding: "utf8"
+  });
+  assert.equal(warningCompile.status, 0);
+  assert.match(warningCompile.stdout, /WARN compile corpus/);
+  assert.match(warningCompile.stdout, /surface-pair-bidirectional-sync/);
+
+  const strictCompile = spawnSync("node", [
+    CLI_PATH,
+    "compile",
+    sourcePath,
+    path.join(tempDir, "compiled-strict"),
+    "--force",
+    "--strict"
+  ], {
+    cwd: REPO_ROOT,
+    encoding: "utf8"
+  });
+  assert.notEqual(strictCompile.status, 0);
+  assert.match(strictCompile.stdout, /FAIL compile corpus/);
+  assert.match(strictCompile.stdout, /strict gate blocked by warnings/);
+  assert.match(strictCompile.stdout, /surface-pair-bidirectional-sync/);
+  assert.ok(fs.existsSync(path.join(tempDir, "compiled-strict", "manifest.json")));
+
+  const strictJsonCompile = spawnSync("node", [
+    CLI_PATH,
+    "compile",
+    sourcePath,
+    path.join(tempDir, "compiled-strict-json"),
+    "--force",
+    "--strict",
+    "--json"
+  ], {
+    cwd: REPO_ROOT,
+    encoding: "utf8"
+  });
+  assert.notEqual(strictJsonCompile.status, 0);
+  const strictJson = JSON.parse(strictJsonCompile.stdout);
+  assert.equal(strictJson.strict, true);
+  assert.equal(strictJson.status, "fail");
+  assert.equal(strictJson.validation.errors, 0);
+  assert.ok(strictJson.validation.warnings > 0);
 });
 
 test("authoring scaffold helpers update source, pair surfaces, and compile successfully", () => {

--- a/bin/aods.mjs
+++ b/bin/aods.mjs
@@ -15,7 +15,7 @@ Usage:
   aods route [root] [--role <role-id>] [--touch <path>] [--query <text>] [--stage <stage>] [--intent <intent>] [--json]
   aods hook pre-commit [root] [--staged] [--repo-root <path>] [--file <path>]... [--json]
   aods upgrade [root] [--json] [--dry-run] [--no-bump]
-  aods compile <source-file> <target-dir> [--json] [--force]
+  aods compile <source-file> <target-dir> [--json] [--strict] [--force]
   aods scaffold corpus <target-dir> --sys <system-id> [--purpose <text>] [--force]
   aods scaffold authoring <target-dir> --sys <system-id> [--purpose <text>] [--force]
   aods scaffold module <corpus-root> <module-id> [--path <relative-path>] [--category <category>] [--layer <layer>] [--pattern <pattern>] [--scope <text>] [--priority <priority>] [--tag <tag>]... [--dep <module-id>]... [--route <target>]... [--boot] [--force]
@@ -28,7 +28,7 @@ Commands:
   route      Resolve minimal module load set for a role, touched file, lexical query, and optional task stage.
   hook       Run hookable enforcement helpers such as pre-commit validation.
   upgrade    Sync schemas and refresh manifest metadata for an existing corpus.
-  compile    Compile concise authoring JSON into an AODS corpus.
+  compile    Compile concise authoring JSON into an AODS corpus and optionally fail on warnings.
   scaffold   Generate new corpus, authoring source, compiled-corpus modules, or safe authoring-source mutations.
 
 Flags:

--- a/lib/compile.mjs
+++ b/lib/compile.mjs
@@ -51,19 +51,46 @@ export async function runCompileCommand(argv) {
   validateAuthoringSource(source, sourcePath);
 
   const compiled = compileAuthoringSource(source, sourceRoot);
-  ensureTargetDirectory(targetRoot, options.force, { cleanOnForce: true });
-  writeCompiledCorpus(targetRoot, compiled);
+  let report = null;
+  let written = false;
+  let stagingRoot = null;
 
-  const report = validateCorpus(targetRoot);
+  if (options.strict) {
+    assertCompileTargetReady(targetRoot, options.force);
+    stagingRoot = createCompileStagingRoot(targetRoot);
+    try {
+      writeCompiledCorpus(stagingRoot, compiled);
+      report = validateCorpus(stagingRoot);
+      const accepted = isCompileAccepted(report.summary, options);
+      if (accepted) {
+        promoteCompiledCorpus(stagingRoot, targetRoot, options.force);
+        written = true;
+        stagingRoot = null;
+      }
+    } finally {
+      if (stagingRoot) {
+        fs.rmSync(stagingRoot, { recursive: true, force: true });
+      }
+    }
+  } else {
+    ensureTargetDirectory(targetRoot, options.force, { cleanOnForce: true });
+    writeCompiledCorpus(targetRoot, compiled);
+    report = validateCorpus(targetRoot);
+    written = true;
+  }
+
+  const accepted = isCompileAccepted(report.summary, options);
   const status = getCompileStatus(report.summary, options);
   const result = {
     action: "compile corpus",
     source: sourcePath,
     root: targetRoot,
-    created_files: compiled.files,
+    created_files: written ? compiled.files : [],
     validation: report.summary,
     strict: options.strict,
-    status
+    status,
+    accepted,
+    written
   };
 
   if (options.json) {
@@ -621,11 +648,16 @@ function printResult(result, report, options) {
   if (options.strict && result.validation.errors === 0 && result.validation.warnings > 0) {
     console.log("strict gate blocked by warnings");
   }
+  if (options.strict && !result.written) {
+    console.log("target not updated because strict gate failed");
+  }
   if (result.status !== "ok") {
     printValidationIssues(report);
   }
-  for (const file of result.created_files) {
-    console.log(`  wrote ${file}`);
+  if (result.written) {
+    for (const file of result.created_files) {
+      console.log(`  wrote ${file}`);
+    }
   }
 }
 
@@ -656,6 +688,43 @@ function printValidationIssues(report) {
 function formatValidationIssue(level, prefix, issue) {
   const location = [issue.module_id, issue.sid].filter(Boolean).join(":");
   return `  ${level} ${prefix} ${issue.rule}${location ? ` @ ${location}` : ""} -> ${issue.message}`;
+}
+
+function isCompileAccepted(validation, options) {
+  return validation.errors === 0 && (!options.strict || validation.warnings === 0);
+}
+
+function assertCompileTargetReady(targetRoot, force) {
+  if (!fs.existsSync(targetRoot)) {
+    fs.mkdirSync(path.dirname(targetRoot), { recursive: true });
+    return;
+  }
+
+  const entries = fs.readdirSync(targetRoot);
+  if (entries.length === 0) {
+    return;
+  }
+
+  if (!force) {
+    throw new Error(`Target directory is not empty: ${targetRoot}. Use --force to write anyway.`);
+  }
+}
+
+function createCompileStagingRoot(targetRoot) {
+  const parentDir = path.dirname(targetRoot);
+  fs.mkdirSync(parentDir, { recursive: true });
+  return fs.mkdtempSync(path.join(parentDir, `${path.basename(targetRoot)}.staging-`));
+}
+
+function promoteCompiledCorpus(stagingRoot, targetRoot, force) {
+  if (fs.existsSync(targetRoot)) {
+    const entries = fs.readdirSync(targetRoot);
+    if (entries.length > 0 && !force) {
+      throw new Error(`Target directory is not empty: ${targetRoot}. Use --force to write anyway.`);
+    }
+    fs.rmSync(targetRoot, { recursive: true, force: true });
+  }
+  fs.renameSync(stagingRoot, targetRoot);
 }
 
 function cloneValue(value) {

--- a/lib/compile.mjs
+++ b/lib/compile.mjs
@@ -55,21 +55,24 @@ export async function runCompileCommand(argv) {
   writeCompiledCorpus(targetRoot, compiled);
 
   const report = validateCorpus(targetRoot);
+  const status = getCompileStatus(report.summary, options);
   const result = {
     action: "compile corpus",
     source: sourcePath,
     root: targetRoot,
     created_files: compiled.files,
-    validation: report.summary
+    validation: report.summary,
+    strict: options.strict,
+    status
   };
 
   if (options.json) {
     console.log(JSON.stringify(result, null, 2));
   } else {
-    printResult(result);
+    printResult(result, report, options);
   }
 
-  return report.summary.errors > 0 ? 1 : 0;
+  return getCompileExitCode(report.summary, options);
 }
 
 function parseArgs(argv) {
@@ -77,6 +80,7 @@ function parseArgs(argv) {
     sourcePath: "",
     targetDir: "",
     json: false,
+    strict: false,
     force: false
   };
 
@@ -85,6 +89,10 @@ function parseArgs(argv) {
     const arg = queue.shift();
     if (arg === "--json") {
       options.json = true;
+      continue;
+    }
+    if (arg === "--strict") {
+      options.strict = true;
       continue;
     }
     if (arg === "--force") {
@@ -103,7 +111,7 @@ function parseArgs(argv) {
   }
 
   if (!options.sourcePath || !options.targetDir) {
-    throw new Error("Usage: compile <source-file> <target-dir> [--json] [--force]");
+    throw new Error("Usage: compile <source-file> <target-dir> [--json] [--strict] [--force]");
   }
 
   return options;
@@ -603,16 +611,51 @@ function writeCompiledCorpus(targetRoot, compiled) {
   }
 }
 
-function printResult(result) {
-  console.log(`OK ${result.action}`);
+function printResult(result, report, options) {
+  console.log(`${result.status.toUpperCase()} ${result.action}`);
   console.log(`source=${result.source}`);
   console.log(`root=${result.root}`);
   console.log(
     `validation errors=${result.validation.errors} warnings=${result.validation.warnings} modules=${result.validation.total_modules}`
   );
+  if (options.strict && result.validation.errors === 0 && result.validation.warnings > 0) {
+    console.log("strict gate blocked by warnings");
+  }
+  if (result.status !== "ok") {
+    printValidationIssues(report);
+  }
   for (const file of result.created_files) {
     console.log(`  wrote ${file}`);
   }
+}
+
+function getCompileExitCode(validation, options) {
+  const hasErrors = validation.errors > 0;
+  const hasWarnings = validation.warnings > 0;
+  return hasErrors || (options.strict && hasWarnings) ? 1 : 0;
+}
+
+function getCompileStatus(validation, options) {
+  if (getCompileExitCode(validation, options) > 0) {
+    return "fail";
+  }
+  return validation.warnings > 0 ? "warn" : "ok";
+}
+
+function printValidationIssues(report) {
+  for (const [level, levelReport] of Object.entries(report.levels)) {
+    for (const issue of levelReport.errors) {
+      console.log(formatValidationIssue(level, "ERROR", issue));
+    }
+    for (const issue of levelReport.warnings) {
+      console.log(formatValidationIssue(level, "WARN", issue));
+    }
+  }
+}
+
+function formatValidationIssue(level, prefix, issue) {
+  const location = [issue.module_id, issue.sid].filter(Boolean).join(":");
+  return `  ${level} ${prefix} ${issue.rule}${location ? ` @ ${location}` : ""} -> ${issue.message}`;
 }
 
 function cloneValue(value) {


### PR DESCRIPTION
## Summary
- add `compile --strict` as a real acceptance gate with staging -> validate -> promote semantics
- preserve existing target output when strict validation fails on warnings or errors
- expose accepted/written compile state and lock the behavior with docs and regression coverage

## Validation
- node --test ./benchmarks/aods-eval-lab/test/scaffold.test.mjs
- npm run validate:all
- npm run benchmark:test

Closes #11