### PR TITLE
Fix strict validate status output

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ node ./bin/aods.mjs validate . --strict --reality
 node ./bin/aods.mjs validate . --strict --reality --repo-root ..
 ```
 
+In `validate --strict`, warning-only corpora now print failure-shaped output instead of a green-looking `PASS` summary. JSON output also includes top-level `strict`, `accepted`, and `status` fields so the acceptance gate stays machine-readable.
+
 ### Route scoped module loads
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -268,6 +268,8 @@ node ./bin/aods.mjs validate . --strict --reality
 node ./bin/aods.mjs validate . --strict --reality --repo-root ..
 ```
 
+在 `validate --strict` 下，只要 warning 让 gate 失败，CLI 现在就会输出 failure-shaped 结果，而不是继续打印一个看起来像绿色通过的 `PASS` 摘要。JSON 输出也会补充顶层的 `strict`、`accepted` 和 `status` 字段，方便机器侧直接判断 gate 是否通过。
+
 ### 对触达文件做 scoped routing
 
 ```bash

--- a/benchmarks/aods-eval-lab/test/scaffold.test.mjs
+++ b/benchmarks/aods-eval-lab/test/scaffold.test.mjs
@@ -138,6 +138,77 @@ test("authoring scaffold helpers update source, pair surfaces, and compile succe
   runCli(["validate", compiledRoot, "--strict"]);
 });
 
+test("validate --strict turns warning-only output into a failing gate", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "aods-validate-strict-"));
+  runCli(["scaffold", "authoring", tempDir, "--sys", "demo-system", "--force"]);
+
+  const sourcePath = path.join(tempDir, "authoring.json");
+  runCli([
+    "scaffold",
+    "authoring-module",
+    sourcePath,
+    "delivery-gates",
+    "--category",
+    "policy",
+    "--layer",
+    "detail",
+    "--scope",
+    "Delivery gate authority"
+  ]);
+  runCli([
+    "scaffold",
+    "authoring-pair",
+    sourcePath,
+    "--pair-id",
+    "pair-delivery-log",
+    "--agent-primary",
+    "delivery-gates",
+    "--human-primary",
+    "DELIVERY-LOG.md"
+  ]);
+
+  const source = JSON.parse(fs.readFileSync(sourcePath, "utf8"));
+  source.surface_pairs[0].sync_source = "bidirectional";
+  fs.writeFileSync(sourcePath, `${JSON.stringify(source, null, 2)}\n`);
+
+  const warningRoot = path.join(tempDir, "compiled-warning");
+  runCli(["compile", sourcePath, warningRoot, "--force"]);
+
+  const strictValidate = spawnSync("node", [
+    CLI_PATH,
+    "validate",
+    warningRoot,
+    "--strict"
+  ], {
+    cwd: REPO_ROOT,
+    encoding: "utf8"
+  });
+  assert.notEqual(strictValidate.status, 0);
+  assert.match(strictValidate.stdout, /FAIL .*compiled-warning/);
+  assert.match(strictValidate.stdout, /strict gate blocked by warnings/);
+  assert.match(strictValidate.stdout, /L3 FAIL errors=0 warnings=1/);
+  assert.match(strictValidate.stdout, /surface-pair-bidirectional-sync/);
+
+  const strictValidateJson = spawnSync("node", [
+    CLI_PATH,
+    "validate",
+    warningRoot,
+    "--strict",
+    "--json"
+  ], {
+    cwd: REPO_ROOT,
+    encoding: "utf8"
+  });
+  assert.notEqual(strictValidateJson.status, 0);
+  const strictValidateReport = JSON.parse(strictValidateJson.stdout);
+  assert.equal(strictValidateReport.strict, true);
+  assert.equal(strictValidateReport.accepted, false);
+  assert.equal(strictValidateReport.status, "fail");
+  assert.equal(strictValidateReport.levels.L3.pass, false);
+  assert.equal(strictValidateReport.summary.errors, 0);
+  assert.equal(strictValidateReport.summary.warnings, 1);
+});
+
 test("implementation-governance pattern scaffolds delivery-governor artifacts", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "aods-implementation-governance-"));
   runCli(["scaffold", "authoring", tempDir, "--sys", "demo-system", "--force"]);

--- a/lib/validate.mjs
+++ b/lib/validate.mjs
@@ -43,10 +43,10 @@ const DEFAULT_PLACEHOLDER_FILES = new Set([".gitkeep", ".keep", ".placeholder", 
 export async function runValidateCommand(argv) {
   const options = parseArgs(argv);
   const rootPath = path.resolve(options.root);
-  const report = validateCorpus(rootPath, {
+  const report = applyValidationGate(validateCorpus(rootPath, {
     reality: options.reality,
     repoRoot: options.repoRoot ? path.resolve(options.repoRoot) : rootPath
-  });
+  }), options);
 
   if (options.json) {
     console.log(JSON.stringify(report, null, 2));
@@ -54,9 +54,7 @@ export async function runValidateCommand(argv) {
     printReport(report, rootPath);
   }
 
-  const hasErrors = report.summary.errors > 0;
-  const hasWarnings = report.summary.warnings > 0;
-  return hasErrors || (options.strict && hasWarnings) ? 1 : 0;
+  return report.accepted ? 0 : 1;
 }
 
 function parseArgs(argv) {
@@ -1544,12 +1542,27 @@ function finalizeReport(report) {
   }
 }
 
+function applyValidationGate(report, options) {
+  for (const level of LEVELS) {
+    const levelReport = report.levels[level];
+    levelReport.pass = levelReport.errors.length === 0 && (!options.strict || levelReport.warnings.length === 0);
+  }
+
+  report.strict = options.strict;
+  report.accepted = report.summary.errors === 0 && (!options.strict || report.summary.warnings === 0);
+  report.status = report.accepted ? "pass" : "fail";
+  return report;
+}
+
 export function printReport(report, rootPath) {
-  const status = report.summary.errors === 0 ? "PASS" : "FAIL";
+  const status = (report.status ?? (report.summary.errors === 0 ? "pass" : "fail")).toUpperCase();
   console.log(`${status} ${rootPath}`);
   console.log(
     `modules=${report.summary.total_modules} sections=${report.summary.total_sections} artifacts=${report.summary.total_artifacts} surface_pairs=${report.summary.total_surface_pairs} errors=${report.summary.errors} warnings=${report.summary.warnings}`
   );
+  if (report.strict && report.summary.errors === 0 && report.summary.warnings > 0) {
+    console.log("strict gate blocked by warnings");
+  }
 
   for (const level of LEVELS) {
     const levelReport = report.levels[level];


### PR DESCRIPTION
## Summary
- make `validate --strict` print failure-shaped output when warnings block the gate
- expose top-level `strict`, `accepted`, and `status` fields in validate JSON output
- lock the warning-only strict-gate behavior with regression coverage and README updates

## Why
This fixes an untracked acceptance-gate drift found during the post-`v0.4.0` trust audit: `validate --strict` already exited non-zero on warnings, but still printed a success-shaped `PASS` summary.

## Validation
- node --test ./benchmarks/aods-eval-lab/test/scaffold.test.mjs
- npm run validate:all
- npm run benchmark:test