### PR TITLE
Fix v0.5.1 release surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AODS is a documentation standard and CLI for teams that want AI agents to work from a clear, governed source of truth instead of piecing together context from scattered project docs.
 
-**Latest release:** `v0.4.0`
+**Latest release:** `v0.5.1`
 
 In this README, **human-oriented docs** means files mainly written for people to read, such as README files, SOPs, or checklists. **Agent-oriented docs** means structured files that agents and tooling can route, validate, and compare. For compatibility, the schema and CLI still use field names such as `human_primary`, `agent_primary`, and `sync_source=agent-primary`.
 
@@ -47,7 +47,7 @@ Requires **Node 18+**.
 1. Install the tagged GitHub release into your project:
 
 ```bash
-npm install --save-dev git+https://github.com/emosamastudio/aods.git#v0.4.0
+npm install --save-dev git+https://github.com/emosamastudio/aods.git#v0.5.1
 ```
 
 2. Verify the CLI is available:
@@ -421,7 +421,7 @@ This project is released under the **MIT License**. See [`LICENSE`](./LICENSE).
 
 AODS now uses two version tracks:
 
-- **Release version:** Git tags and package releases such as `v0.4.0`
+- **Release version:** Git tags and package releases such as `v0.5.1`
 - **Release-aligned skill version:** packaged skills under `skills/` stay aligned to the same release tag
 - **Schema compatibility:** surface-local markers such as `aods_v` and `authoring_v`
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 AODS 是一套文档标准和 CLI，适合那些希望让 AI agent 基于清晰、可验证、可治理的事实源工作，而不是从零散项目文档里拼接上下文的团队。
 
-**当前最新版本：** `v0.4.0`
+**当前最新版本：** `v0.5.1`
 
 在这份 README 里，**面向人阅读的文档** 指 README、SOP、检查清单这类主要给人看的文件；**面向 agent 的结构化文档** 指那些可以被 agent 和工具路由、校验、比较的结构化文件。为了兼容，schema 和 CLI 仍然保留 `human_primary`、`agent_primary`、`sync_source=agent-primary` 这类字段名。
 
@@ -47,7 +47,7 @@ AODS 走的是一条明确的路径，而不是泛化地宣称“所有场景都
 1. 先把带版本 tag 的 GitHub 发布版安装到你的项目里：
 
 ```bash
-npm install --save-dev git+https://github.com/emosamastudio/aods.git#v0.4.0
+npm install --save-dev git+https://github.com/emosamastudio/aods.git#v0.5.1
 ```
 
 2. 确认 CLI 可用：
@@ -419,7 +419,7 @@ node ./bin/aods.mjs scaffold authoring-pair ./examples/compiled-pilot-source/aut
 
 AODS 现在区分两条版本线：
 
-- **发布版本：** Git tag / package release，例如 `v0.4.0`
+- **发布版本：** Git tag / package release，例如 `v0.5.1`
 - **与发布版对齐的 skill 版本：** `skills/` 下的技能与同一个 release tag 对齐
 - **Schema 兼容版本：** 各 surface 内部使用的兼容性标记，例如 `aods_v` 和 `authoring_v`
 

--- a/benchmarks/aods-eval-lab/test/skill-package.test.mjs
+++ b/benchmarks/aods-eval-lab/test/skill-package.test.mjs
@@ -31,3 +31,24 @@ test("aods-use skill stays release-aligned and keeps a narrow trigger contract",
   assert.ok(skillMeta.positive_triggers.some((item) => item.includes("surface_pairs")));
   assert.ok(skillMeta.negative_triggers.some((item) => item.includes("generic README")));
 });
+
+test("release self-check keeps public version surfaces aligned", () => {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"));
+  const packageLock = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package-lock.json"), "utf8"));
+  const readme = fs.readFileSync(path.join(REPO_ROOT, "README.md"), "utf8");
+  const readmeZh = fs.readFileSync(path.join(REPO_ROOT, "README.zh-CN.md"), "utf8");
+  const version = packageJson.version;
+  const releaseTag = `v${version}`;
+
+  assert.equal(packageJson.scripts["release:self-check"], "npm run validate:repo && npm pack --dry-run");
+  assert.equal(packageLock.version, version);
+  assert.equal(packageLock.packages[""].version, version);
+
+  assert.ok(readme.includes(`**Latest release:** \`${releaseTag}\``));
+  assert.ok(readme.includes(`npm install --save-dev git+https://github.com/emosamastudio/aods.git#${releaseTag}`));
+  assert.ok(readme.includes(`Git tags and package releases such as \`${releaseTag}\``));
+
+  assert.ok(readmeZh.includes(`**当前最新版本：** \`${releaseTag}\``));
+  assert.ok(readmeZh.includes(`npm install --save-dev git+https://github.com/emosamastudio/aods.git#${releaseTag}`));
+  assert.ok(readmeZh.includes(`Git tag / package release，例如 \`${releaseTag}\``));
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aods",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aods",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aods",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "private": false,
   "description": "AODS standard and CLI for agent-first documentation, routing, and anti-drift governance",
   "type": "module",
@@ -62,7 +62,8 @@
     "benchmark:summary": "npm --prefix ./benchmarks/aods-eval-lab run summary",
     "benchmark:test": "npm --prefix ./benchmarks/aods-eval-lab run test",
     "benchmark:all": "npm run benchmark:evaluate && npm run benchmark:compare && npm run benchmark:summary && npm run benchmark:test",
-    "validate:repo": "npm run validate:all && npm run benchmark:all"
+    "validate:repo": "npm run validate:all && npm run benchmark:all",
+    "release:self-check": "npm run validate:repo && npm pack --dry-run"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/skills/aods-use/SKILL.md
+++ b/skills/aods-use/SKILL.md
@@ -9,8 +9,8 @@ Use this skill as an operations adapter, not as a second copy of the AODS spec.
 
 ## Version alignment
 
-- Release version: `v0.4.0`
-- Package version: `0.4.0`
+- Release version: `v0.5.1`
+- Package version: `0.5.1`
 - Compatibility markers: `aods_v=3`, `authoring_v=1`
 - Source of truth: installed AODS CLI plus repo `schema/`, `spec/`, and manifest surfaces
 

--- a/skills/aods-use/skill.json
+++ b/skills/aods-use/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "aods-use",
-  "skill_version": "0.4.0",
-  "aligned_release": "v0.4.0",
+  "skill_version": "0.5.1",
+  "aligned_release": "v0.5.1",
   "entrypoint": "SKILL.md",
   "compatibility": {
     "aods_v": 3,


### PR DESCRIPTION
## Summary
- correct the public version surfaces from 0.4.0/v0.4.0 to 0.5.1/v0.5.1
- add a release:self-check script so validate + pack inspection happen before future releases
- add a regression test that locks package, README, and skill version alignment to package.json

## Why
v0.5.0 was published with the trust-wave code but stale public version surfaces. This corrective patch prepares the clean follow-up release as v0.5.1.

## Validation
- npm run release:self-check
